### PR TITLE
Add preact to nanocomponent adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var button = document.createElement('button', 'custom-button')
 document.body.appendChild(button)
 ```
 
-## Preact (to be implemented)
+## Preact
 ```js
 var toPreact = require('nanocomponent-adapters/preact')
 var component = require('nanocomponent')

--- a/preact.js
+++ b/preact.js
@@ -1,0 +1,41 @@
+var assert = require('assert')
+
+module.exports = toPreact
+
+function toPreact (component, preact) {
+  assert.equal(typeof component, 'function', 'nanocomponent-adapters/preact: component should be type function')
+  assert.equal(typeof preact, 'object', 'nanocomponent-adapters/preact: preact should be type object')
+
+  var element = null
+  var props = null
+  var node = null
+
+  class clx extends preact.Component {
+    shouldComponentUpdate (nextProps) {
+      return false
+    }
+
+    componentDidMount () {
+      if (!element) {
+        element = component(props)
+        node.appendChild(element)
+      }
+    }
+
+    componentWillReceiveProps (nwProps) {
+      props = nwProps
+      if (element) element(props)
+    }
+
+    setRef (_node) {
+      node = _node
+    }
+
+    render (_props) {
+      props = _props
+      return preact.h('div', { ref: this.setRef })
+    }
+  }
+
+  return clx
+}

--- a/preact.js
+++ b/preact.js
@@ -10,32 +10,37 @@ function toPreact (component, preact) {
   var props = null
   var node = null
 
-  class clx extends preact.Component {
-    shouldComponentUpdate (nextProps) {
-      return false
-    }
+  function setRef (_node) {
+    node = _node
+  }
 
-    componentDidMount () {
-      if (!element) {
-        element = component(props)
-        node.appendChild(element)
-      }
-    }
+  function Clx () {
+    preact.Component.apply(this, arguments)
+  }
 
-    componentWillReceiveProps (nwProps) {
-      props = nwProps
-      if (element) element(props)
-    }
+  Clx.prototype = Object.create(preact.Component)
+  Clx.prototype.constructor = preact.Component
 
-    setRef (_node) {
-      node = _node
-    }
-
-    render (_props) {
-      props = _props
-      return preact.h('div', { ref: this.setRef })
+  Clx.prototype.componentDidMount = function componentDidMount () {
+    if (!element) {
+      element = component(props)
+      node.appendChild(element)
     }
   }
 
-  return clx
+  Clx.prototype.componentWillReceiveProps = function componentWillReceiveProps (nwProps) {
+    props = nwProps
+    if (element) element(props)
+  }
+
+  Clx.prototype.shouldComponentUpdate = function shouldComponentUpdate () {
+    return false
+  }
+
+  Clx.prototype.render = function render (_props) {
+    props = _props
+    return preact.h('div', { ref: setRef })
+  }
+
+  return Clx
 }


### PR DESCRIPTION
Preact does not have `createClass`. You can emulate it of course, but I did not know if you wanted to do that. Just let me know what you think and I will update PR if needed.

#2 